### PR TITLE
Add CLI tool for building collection from the command line

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -164,11 +164,14 @@ jobs:
 
       # Restore cached files to speed things up
       - restore_cache:
-          key: deps-{{ .Branch }}-3.7-{{ checksum "ci/environment-dev-3.7.yml" }}
+          key: deps-{{ .Branch }}-{{ checksum "docs/environment.yml" }}
 
       - run: # install and activate conda environment
           name: Install conda environment
-          command: ./ci/install-circle.sh
+          command: |
+            conda env update -f docs/environment.yml
+            source activate ${ENV_NAME}
+            python setup.py install
 
       - run:
           name: Check documentation build
@@ -181,7 +184,7 @@ jobs:
 
       # Cache some files for a speedup in subsequent builds
       - save_cache:
-          key: deps-{{ .Branch }}-3.7-{{ checksum "ci/environment-dev-3.7.yml" }}
+          key: deps-{{ .Branch }}-{{ checksum "docs/environment.yml" }}
           paths:
             - "/opt/conda/envs/${ENV_NAME}/"
             - "/opt/conda/pkgs"

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,6 +17,8 @@ Features
 
 - Split collection definitions out of config. (:pr:`83`) `Matthew Long`_
 
+- Add ``intake-esm-builder``, a CLI tool for building collection from the command line. (:pr:`89`) `Anderson Banihirwe`_
+
 
 Bug Fixes
 ----------
@@ -31,6 +33,7 @@ Internal Changes
 ----------------
 
 - Refactor existing functionality to make intake-esm robust and extensible. (:pr:`77`) `Anderson Banihirwe`_
+
 
 
 Intake-esm v2019.5.11 (2019-05-11)

--- a/ci/environment-dev-3.6.yml
+++ b/ci/environment-dev-3.6.yml
@@ -20,3 +20,4 @@ dependencies:
   - tqdm
   - xarray
   - docrep
+  - click

--- a/ci/environment-dev-3.7.yml
+++ b/ci/environment-dev-3.7.yml
@@ -30,3 +30,4 @@ dependencies:
   - tqdm
   - xarray
   - docrep
+  - click

--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -1,0 +1,16 @@
+name: intake-esm-dev
+channels:
+  - conda-forge
+dependencies:
+  - dask
+  - intake
+  - intake-xarray
+  - nbsphinx
+  - numpydoc
+  - python=3.7
+  - pyyaml
+  - sphinx_rtd_theme
+  - tqdm
+  - xarray
+  - docrep
+  - click

--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -14,3 +14,4 @@ dependencies:
   - xarray
   - docrep
   - click
+  - jupyterlab

--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -14,4 +14,6 @@ dependencies:
   - xarray
   - docrep
   - click
+  - git
+  - make
   - jupyterlab

--- a/intake_esm/cli.py
+++ b/intake_esm/cli.py
@@ -1,8 +1,16 @@
 #! /usr/bin/env python
+import os
+
 import click
 import intake
 
 from intake_esm import ESMMetadataStoreCatalog, config
+
+# http://click.palletsprojects.com/en/5.x/python3/
+# Enforce en_US.utf-8 as the encoding of choice
+
+os.environ['LC_ALL'] = 'C.UTF-8'
+os.environ['LANG'] = 'C.UTF-8'
 
 _default_database_dir = config.get('database-directory')
 

--- a/intake_esm/cli.py
+++ b/intake_esm/cli.py
@@ -2,9 +2,10 @@
 import os
 
 import click
-import intake
 
-from intake_esm import ESMMetadataStoreCatalog, config
+from . import config
+from .bld_collection_utils import load_collection_input_file
+from .core import ESMMetadataStoreCatalog
 
 # http://click.palletsprojects.com/en/5.x/python3/
 # Enforce en_US.utf-8 as the encoding of choice
@@ -16,6 +17,12 @@ _default_database_dir = config.get('database-directory')
 
 
 def _builder(collection_input_definition, overwrite_existing, database_dir):
+    if not collection_input_definition:
+        load_collection_input_file()
+        raise ValueError(
+            f'\n\n*** Please specify collection input name from the list above '
+            'or collection input YAML file. ***'
+        )
     with config.set({'database-dir': database_dir}):
         ESMMetadataStoreCatalog(collection_input_definition, overwrite_existing=overwrite_existing)
 
@@ -24,9 +31,10 @@ def _builder(collection_input_definition, overwrite_existing, database_dir):
 @click.option(
     '--collection-input-definition',
     '-cdef',
+    default=None,
     help='Path to a collection input YAML file '
     'or a name of supported collection input'
-    '(see: https://github.com/NCAR/intake-esm-datastore)',
+    '(see: https://github.com/NCAR/intake-esm-datastore) for list of supported collection inputs.',
 )
 @click.option(
     '--overwrite-existing',
@@ -40,7 +48,7 @@ def _builder(collection_input_definition, overwrite_existing, database_dir):
     '-db',
     type=str,
     default=_default_database_dir,
-    help='Directory in which to perist the built collection database',
+    help='Directory in which to persist the built collection database',
     show_default=True,
 )
 def main(collection_input_definition, overwrite_existing, database_dir):

--- a/intake_esm/cli.py
+++ b/intake_esm/cli.py
@@ -1,0 +1,41 @@
+#! /usr/bin/env python
+import click
+import intake
+
+from intake_esm import ESMMetadataStoreCatalog, config
+
+_default_database_dir = config.get('database-directory')
+
+
+def _builder(collection_input_definition, overwrite_existing, database_dir):
+    with config.set({'database-dir': database_dir}):
+        ESMMetadataStoreCatalog(collection_input_definition, overwrite_existing=overwrite_existing)
+
+
+@click.command()
+@click.option(
+    '--collection-input-definition',
+    help='Path to a collection input YAML file '
+    'or a name of supported collection input'
+    '(see: https://github.com/NCAR/intake-esm-datastore)',
+)
+@click.option(
+    '--overwrite-existing',
+    default=False,
+    is_flag=True,
+    help='Whether or not to overwrite the existing database file.',
+    show_default=True,
+)
+@click.option(
+    '--database-dir',
+    type=str,
+    default=_default_database_dir,
+    help='Directory in which to perist the built collection database',
+    show_default=True,
+)
+def main(collection_input_definition, overwrite_existing, database_dir):
+    _builder(collection_input_definition, overwrite_existing, database_dir)
+
+
+if __name__ == '__main__':
+    main()

--- a/intake_esm/cli.py
+++ b/intake_esm/cli.py
@@ -15,6 +15,7 @@ def _builder(collection_input_definition, overwrite_existing, database_dir):
 @click.command()
 @click.option(
     '--collection-input-definition',
+    '-cdef',
     help='Path to a collection input YAML file '
     'or a name of supported collection input'
     '(see: https://github.com/NCAR/intake-esm-datastore)',
@@ -28,6 +29,7 @@ def _builder(collection_input_definition, overwrite_existing, database_dir):
 )
 @click.option(
     '--database-dir',
+    '-db',
     type=str,
     default=_default_database_dir,
     help='Directory in which to perist the built collection database',

--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -1,5 +1,5 @@
 conda:
-  file: ci/environment-dev-3.7.yml
+  file: docs/environment.yml
 python:
   version: 3
   setup_py_install: true

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ pyyaml
 tqdm
 intake-xarray
 docrep
+click

--- a/setup.cfg
+++ b/setup.cfg
@@ -10,7 +10,7 @@ select = B,C,E,F,W,T4,B9
 
 [isort]
 known_first_party=intake_esm
-known_third_party=dask,docrep,intake,intake_xarray,numpy,pandas,pkg_resources,pytest,setuptools,tqdm,xarray,yaml
+known_third_party=click,dask,docrep,intake,intake_xarray,numpy,pandas,pkg_resources,pytest,setuptools,tqdm,xarray,yaml
 multi_line_output=3
 include_trailing_comma=True
 force_grid_wrap=0

--- a/setup.py
+++ b/setup.py
@@ -6,11 +6,9 @@ from os.path import exists
 
 from setuptools import find_packages, setup
 
-if exists('requirements.txt'):
-    with open('requirements.txt') as f:
-        install_requires = f.read().strip().split('\n')
-else:
-    install_requires = ['intake', 'xarray', 'pyyaml', 'tqdm', 'intake-xarray']
+with open('requirements.txt') as f:
+    install_requires = f.read().strip().split('\n')
+
 
 if exists('README.rst'):
     with open('README.rst') as f:
@@ -45,6 +43,10 @@ setup(
     install_requires=install_requires,
     license='Apache 2.0',
     zip_safe=False,
+    entry_points="""
+    [console_scripts]
+    intake-esm-builder=intake_esm.cli:main
+    """,
     keywords='intake-esm',
     use_scm_version={'version_scheme': 'post-release', 'local_scheme': 'dirty-tag'},
     setup_requires=['setuptools_scm', 'setuptools>=30.3.0'],

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,22 @@
+import os
+import subprocess
+
+here = os.path.abspath(os.path.dirname(__file__))
+
+
+def test_basic():
+
+    collection_input_definition = os.path.join(here, 'copy-to-cache-collection-input.yml')
+    p = subprocess.Popen(
+        [
+            'intake-esm-builder',
+            '--collection-input-definition',
+            collection_input_definition,
+            '--overwrite-existing',
+        ],
+        stdin=subprocess.DEVNULL,
+    )
+
+    p.communicate()
+
+    assert p.returncode == 0

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -20,3 +20,11 @@ def test_basic():
     p.communicate()
 
     assert p.returncode == 0
+
+
+def test_empty_input():
+    p = subprocess.Popen(['intake-esm-builder'], stdin=subprocess.DEVNULL)
+
+    p.communicate()
+
+    assert p.returncode != 0


### PR DESCRIPTION
@matt-long, this addresses https://github.com/NCAR/intake-esm-datastore/issues/7

Let me know if you prefer a different name other than `intake-esm-builder`


```bash
$ intake-esm-builder -cdef GLADE-RDA-ERA5 --overwrite-existing
```

```bash
Getting file listing: RDA-GLADE:ERA5:posix:/glade/collections/rda/data/ds630.0
file listing: 100%|█████████████████████████████████████████████████| 169144/169144 [00:01<00:00, 104892.41it/s]
<class 'pandas.core.frame.DataFrame'>
RangeIndex: 169144 entries, 0 to 169143
Data columns (total 19 columns):
direct_access            169144 non-null bool
file_basename            169144 non-null object
file_dirname             169144 non-null object
file_fullpath            169144 non-null object
forecast_initial_date    48790 non-null object
forecast_initial_hour    48790 non-null object
grid                     169144 non-null object
level_type               169130 non-null object
local_table              169144 non-null object
product_type             169144 non-null object
reanalysis_day           120340 non-null object
reanalysis_month         120340 non-null object
reanalysis_year          120340 non-null object
resource                 169144 non-null object
resource_type            169144 non-null object
stream                   169144 non-null object
variable_id              169144 non-null object
variable_short_name      169144 non-null object
variable_type            169130 non-null object
dtypes: bool(1), object(18)
memory usage: 23.4+ MB
None
Persisting GLADE-RDA-ERA5 at : /glade/u/home/abanihi/.intake_esm/collections/era5/GLADE-RDA-ERA5.era5.csv
/glade/work/abanihi/devel/ncar/intake-esm/intake_esm/core.py:81: DtypeWarning: Columns (5,6) have mixed types. Specify dtype option on import or set low_memory=False.
  self.build_collection(overwrite_existing)
```


```bash
$ intake-esm-builder --help
Usage: intake-esm-builder [OPTIONS]

Options:
  -cdef, --collection-input-definition TEXT
                                  Path to a collection input YAML file or a
                                  name of supported collection input(see:
                                  https://github.com/NCAR/intake-esm-
                                  datastore)
  --overwrite-existing            Whether or not to overwrite the existing
                                  database file.  [default: False]
  -db, --database-dir TEXT        Directory in which to perist the built
                                  collection database  [default: /glade/u/home
                                  /abanihi/.intake_esm/collections]
  --help                          Show this message and exit.
```
