### PR TITLE
restore non_dim_coords when there are no time levels to concat over

### DIFF
--- a/intake_esm/aggregate.py
+++ b/intake_esm/aggregate.py
@@ -112,7 +112,7 @@ def concat_time_levels(dsets, time_coord_name_default):
     """
     dsets = dask.compute(*dsets)
     if len(dsets) == 1:
-        return dsets[0]
+        return _restore_non_dim_coords(dsets[0])
 
     attrs = dict_union(*[ds.attrs for ds in dsets])
 


### PR DESCRIPTION
Patch #91 half baked solution
