### PR TITLE
Made experiment independent dataset field for cordex data

### DIFF
--- a/intake_esm/cordex.py
+++ b/intake_esm/cordex.py
@@ -49,7 +49,7 @@ class CORDEXSource(BaseSource):
             'frequency',
             'grid',
             'bias_corrected_or_raw',
-            'experiment'
+            'experiment',
         ]
 
         kwargs = self._validate_kwargs(self.kwargs)

--- a/intake_esm/cordex.py
+++ b/intake_esm/cordex.py
@@ -49,6 +49,7 @@ class CORDEXSource(BaseSource):
             'frequency',
             'grid',
             'bias_corrected_or_raw',
+            'experiment'
         ]
 
         kwargs = self._validate_kwargs(self.kwargs)


### PR DESCRIPTION
Intake-esm automatically concatenates time for historical and rcp85 or other scenarios which is not ideal. Encoding information is lost in this concatenation.