### PR TITLE
add mistral collections to bld_coll_utils

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,6 +8,7 @@ Intake-esm v2019.8.xx (2019-08-xx)
 
 Features
 --------
+- Add `mistral` data holdings to `intake-esm-datastore` (:pr:`1xx`) `Aaron Spring`_
 
 - Add support for `NA-CORDEX`_ data holdings. (:pr:`115`) `Julia Kent`_
 

--- a/intake_esm/bld_collection_utils.py
+++ b/intake_esm/bld_collection_utils.py
@@ -27,6 +27,9 @@ aliases = [
     'MPI-GE',
     'AWS-CESM1-LE',
     'GLADE-NA-CORDEX',
+    'mistral-CMIP5',
+    'mistral-CMIP6',
+    'mistral-MPIGE'
 ]
 
 true_file_names = [
@@ -38,6 +41,9 @@ true_file_names = [
     'mpige-collection',
     'aws-cesm1-le-collection',
     'glade-na-cordex-collection',
+    'mistral-cmip5-collection',
+    'mistral-cmip6-collection',
+    'mistral-mpige-collection',
 ]
 
 
@@ -50,6 +56,12 @@ descriptions = [
     'The Max Planck Institute for Meteorology (MPI-M) Grand Ensemble (MPI-GE) data holdings',
     'Community Earth System Model Large Ensemble (CESM LENS) data holdings publicly available on Amazon S3 (us-west-2 region)',
     'The North American CORDEX program data holdings @ NCAR',
+    'Coupled Model Intercomparison Project - Phase 5 data holdings @ \
+     dkrz.mistral',
+    'Coupled Model Intercomparison Project - Phase 6 data holdings @ \
+     dkrz.mistral',
+    'Max Planck Institute for Meteorology Grand Ensemble (MPI-ESM GE) cmorized \
+     data holdings @ dkrz.mistral'
 ]
 
 
@@ -212,7 +224,8 @@ def get_subset(collection_name, query, order_by=None):
     query_results = ds.where(condition, drop=True)
 
     if order_by is None:
-        order_by = config.get('collections')[collection_type]['order-by-columns']
+        order_by = config.get('collections')[
+            collection_type]['order-by-columns']
 
     query_results = query_results.sortby(order_by, ascending=True)
     return query_results
@@ -346,14 +359,17 @@ def _ensure_file_access(
 
         else:
             file_remote = row[file_fullpath_column_name]
-            file_local = os.path.join(data_cache_directory, os.path.basename(file_remote))
+            file_local = os.path.join(
+                data_cache_directory, os.path.basename(file_remote))
             local_urlpaths.append(file_local)
 
             if not os.path.exists(file_local):
                 if row.resource_type not in resource_types:
-                    raise ValueError(f'unknown resource type: {row.resource_type}')
+                    raise ValueError(
+                        f'unknown resource type: {row.resource_type}')
 
-                file_remote_local[row.resource_type].append((file_remote, file_local))
+                file_remote_local[row.resource_type].append(
+                    (file_remote, file_local))
 
     for res_type in resource_types:
         if file_remote_local[res_type]:


### PR DESCRIPTION
Add CMIP5, CMIP6 and cmorized MPIGE collections to `intake-esm-datastore` and link in `bld_collection_utils.py`.

See `intake-esm-datastore` PR: 

Open questions:
-  [ ]: what about existing non-cmorized mpige collection? needed? cmorized is much faster but contains less datastreams 