### PR TITLE
Return asset's attributes as keys when `aggregate=False`

### DIFF
--- a/intake_esm/core.py
+++ b/intake_esm/core.py
@@ -404,8 +404,9 @@ class esm_datastore(intake.catalog.Catalog, intake_xarray.base.DataSourceMixin):
         if agg_columns:
             keys = '.'.join(groupby_attrs)
         else:
-            keys = path_column_name
-
+            keys = groupby_attrs.copy()
+            keys.remove(path_column_name)
+            keys = '.'.join(keys)
         print(
             f"""--> The keys in the returned dictionary of datasets are constructed as follows:\n\t'{keys}'"""
         )
@@ -485,7 +486,11 @@ def _load_group_dataset(
         group_id = '.'.join(key)
     else:
         nd = df.iloc[0][path_column_name]
-        group_id = nd
+        # Cast key from tuple to list
+        key = list(key)
+        # Remove path from the list
+        key.remove(nd)
+        group_id = '.'.join(key)
 
     if use_format_column:
         format_column_name = col_data['assets']['format_column_name']


### PR DESCRIPTION
Addresses https://github.com/NCAR/intake-esm/issues/163#issuecomment-543899740


```python
import intake
col_file = "https://raw.githubusercontent.com/NCAR/intake-esm-datastore/master/catalogs/pangeo-cmip6.json"

col = intake.open_esm_datastore(col_file)
query = dict(experiment_id='historical', table_id='Oyr', 
                 variable_id='o2', grid_label='gn', member_id='r1i1p1f1')
cat = col.search(**query)
```

```python

# Disable aggregations
In [21]: dsets_pp = cat.to_dataset_dict(zarr_kwargs={"consolidated": True}, aggregate=False)                                                                                         
--> The keys in the returned dictionary of datasets are constructed as follows:
        'activity_id.institution_id.source_id.experiment_id.member_id.table_id.variable_id.grid_label'

--> There will be 2 group(s)

In [22]: dsets_pp.keys()                                                                                                                                                              
Out[22]: dict_keys(['CMIP.CCCma.CanESM5.historical.r1i1p1f1.Oyr.o2.gn', 'CMIP.IPSL.IPSL-CM6A-LR.historical.r1i1p1f1.Oyr.o2.gn'])

```