### PR TITLE
Simplify group loading by using concurrent.futures

### DIFF
--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -10,3 +10,4 @@ dependencies:
   - dask
   - jupyter_client
   - watermark
+  - matplotlib

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,6 @@
 intake-xarray>=0.3.1
 xarray>=0.13.0
-pyyaml
-tqdm
 fsspec
 s3fs
 gcsfs
+requests

--- a/setup.cfg
+++ b/setup.cfg
@@ -7,7 +7,7 @@ select = B,C,E,F,W,T4,B9
 
 [isort]
 known_first_party=intake_esm
-known_third_party=dask,fsspec,intake,intake_xarray,numpy,pandas,pkg_resources,pytest,requests,setuptools,xarray,yaml
+known_third_party=fsspec,intake,intake_xarray,numpy,pandas,pkg_resources,pytest,requests,setuptools,xarray,yaml
 multi_line_output=3
 include_trailing_comma=True
 force_grid_wrap=0


### PR DESCRIPTION
- The previous implementation relied on `dask.delayed` which is somewhat overkill and slow when the user has spawned a dask cluster and is waiting for workers to be provisioned (this causes the group dataset loading to just hang). 

- Also, this PR adds a progress bar (when tqdm is present)

```python
In [7]: dset_dict = cat.to_dataset_dict(zarr_kwargs={'consolidated': True})                                                                        
--> The keys in the returned dictionary of datasets are constructed as follows:
        'activity_id.institution_id.source_id.experiment_id.table_id.grid_label'

--> There will be 7 group(s)
100%|████████████████████████████████████████████| 7/7 [01:15<00:00, 15.63s/it]
```