### PR TITLE
Use dask cluster if available

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,7 +39,8 @@ shared: &shared
     - run:
         name: Running Tests
         command: |
-          pytest -n 8 --junitxml=test-reports/junit.xml --cov=./ --verbose
+          pytest --junitxml=test-reports/junit.xml --cov=./ --verbose
+        no_output_timeout: 30m
     - run:
         name: Uploading code coverage report
         command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,6 +31,7 @@ shared: &shared
         name: Install dependencies in (base environment)
         command: |
           conda env update -n base -f ${ENV_FILE}
+          python -m pip install .
 
     - run:
         name: List packages in the current environment (base)
@@ -39,7 +40,7 @@ shared: &shared
     - run:
         name: Running Tests
         command: |
-          pytest --junitxml=test-reports/junit.xml --cov=./ --verbose
+          pytest -n 4 --junitxml=test-reports/junit.xml --cov=./ --verbose
         no_output_timeout: 30m
     - run:
         name: Uploading code coverage report

--- a/ci/environment-upstream-dev.yml
+++ b/ci/environment-upstream-dev.yml
@@ -9,6 +9,7 @@ dependencies:
   - pytest-cov
   - pytest-icdiff
   - pytest-xdist
+  - pytest-sugar
   - pyyaml
   - toolz
   - zarr

--- a/ci/environment.yml
+++ b/ci/environment.yml
@@ -11,6 +11,7 @@ dependencies:
   - pytest-cov
   - pytest-icdiff
   - pytest-xdist
+  - pytest-sugar
   - pyyaml
   - s3fs
   - xarray

--- a/intake_esm/_util.py
+++ b/intake_esm/_util.py
@@ -1,35 +1,8 @@
 # -*- coding: utf-8 -*-
 import logging
-import sys
 
 logger = logging.getLogger('intake-esm')
 handle = logging.StreamHandler()
 formatter = logging.Formatter('%(asctime)s - %(name)s - %(levelname)s ' '- %(message)s')
 handle.setFormatter(formatter)
 logger.addHandler(handle)
-
-
-# Ref: https://stackoverflow.com/questions/3173320/text-progress-bar-in-the-console
-# https://gist.github.com/aubricus/f91fb55dc6ba5557fbab06119420dd6a
-def print_progressbar(iteration, total, prefix='', suffix='', decimals=1, bar_length=100):
-    """
-    Call in a loop to create terminal progress bar
-    @params:
-        iteration   - Required  : current iteration (Int)
-        total       - Required  : total iterations (Int)
-        prefix      - Optional  : prefix string (Str)
-        suffix      - Optional  : suffix string (Str)
-        decimals    - Optional  : positive number of decimals in percent complete (Int)
-        bar_length  - Optional  : character length of bar (Int)
-    """
-    str_format = '{0:.' + str(decimals) + 'f}'
-    percents = str_format.format(100 * (iteration / float(total)))
-    filled_length = int(round(bar_length * iteration / float(total)))
-    bar = '█' * filled_length + '-' * (bar_length - filled_length)
-
-    sys.stdout.write('\r%s |%s| %s%s %s' % (prefix, bar, percents, '%', suffix)),
-    # sys.stdout.write('%s |%s| %s%s %s\r' % (prefix, bar, percents, '%', suffix)),
-
-    if iteration == total:
-        sys.stdout.write('\n')
-    sys.stdout.flush()

--- a/intake_esm/core.py
+++ b/intake_esm/core.py
@@ -1,16 +1,16 @@
 import copy
 import json
 import logging
-from concurrent import futures
 from urllib.parse import urlparse
 
+import dask
 import fsspec
 import intake
 import numpy as np
 import pandas as pd
 import requests
 
-from ._util import logger, print_progressbar
+from ._util import logger
 from .merge_util import _aggregate, _create_asset_info_lookup, _to_nested_dict
 
 
@@ -450,40 +450,55 @@ class esm_datastore(intake.catalog.Catalog):
 
         dsets = []
         total = len(groups)
-        logger.info(f'Using {total} threads for loading dataset groups')
-        with futures.ThreadPoolExecutor(max_workers=total) as executor:
-            future_tasks = [
-                executor.submit(
-                    _load_group_dataset,
-                    key,
-                    df,
-                    self._col_data,
-                    agg_columns,
-                    aggregation_dict,
-                    path_column_name,
-                    variable_column_name,
-                    use_format_column,
-                    mapper_dict,
-                    self.zarr_kwargs,
-                    self.cdf_kwargs,
-                    self.preprocess,
-                )
-                for key, df in groups
-            ]
+        load_group_dataset_delayed = dask.delayed(_load_group_dataset)
+        tasks = [
+            load_group_dataset_delayed(
+                key,
+                df,
+                self._col_data,
+                agg_columns,
+                aggregation_dict,
+                path_column_name,
+                variable_column_name,
+                use_format_column,
+                mapper_dict,
+                self.zarr_kwargs,
+                self.cdf_kwargs,
+                self.preprocess,
+            )
+            for key, df in groups
+        ]
+
+        client = _get_dask_client()
+
+        if self.progressbar:
+            print(
+                f"""\n--> The keys in the returned dictionary of datasets are constructed as follows:\n\t'{keys}'
+                \n--> There are {len(groups)} group(s)"""
+            )
+
+        if client is None:
+            from multiprocessing.pool import ThreadPool
 
             if self.progressbar:
-                print(
-                    f"""\n--> The keys in the returned dictionary of datasets are constructed as follows:\n\t'{keys}'
-             \n--> There are {len(groups)} group(s)"""
-                )
-                print_progressbar(0, total, prefix='Progress:', suffix='', bar_length=79)
+                from dask.diagnostics import ProgressBar
 
-            for i, task in enumerate(futures.as_completed(future_tasks)):
-                result = task.result()
-                dsets.append(result)
-                if self.progressbar:
-                    # Update Progress Bar
-                    print_progressbar(i + 1, total, prefix='Progress:', suffix='', bar_length=79)
+                ProgressBar().register()
+            with dask.config.set(pool=ThreadPool(total)):
+                logger.info(f'Using {total} threads for loading dataset groups')
+                dsets = dask.compute(*tasks)
+
+        else:
+            if self.progressbar:
+                from distributed import progress
+
+            logger.info(f'Using dask cluster: {client} for loading dataset groups')
+            futures = client.compute(tasks)
+
+            if self.progressbar:
+                progress(futures)
+
+            dsets = client.gather(futures)
 
         self._ds = {group_id: ds for (group_id, ds) in dsets}
         return self._ds
@@ -623,3 +638,16 @@ def _fetch_and_parse_file(input_path):
 def _path_to_mapper(path, storage_options):
     """Convert path to mapper"""
     return fsspec.get_mapper(path, **storage_options)
+
+
+def _get_dask_client():
+    # Detect local default cluster already running
+    # and use it for dataset group loading.
+    try:
+        from distributed.client import _get_global_client
+
+        client = _get_global_client()
+    except ImportError:
+        client = None
+
+    return client

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
-intake-xarray>=0.3.1
 xarray>=0.13.0
 fsspec
 s3fs
 gcsfs
 requests
+dask

--- a/setup.cfg
+++ b/setup.cfg
@@ -7,7 +7,7 @@ select = B,C,E,F,W,T4,B9
 
 [isort]
 known_first_party=intake_esm
-known_third_party=fsspec,intake,numpy,pandas,pkg_resources,pytest,requests,setuptools,xarray,yaml
+known_third_party=dask,fsspec,intake,numpy,pandas,pkg_resources,pytest,requests,setuptools,xarray,yaml
 multi_line_output=3
 include_trailing_comma=True
 force_grid_wrap=0


### PR DESCRIPTION
Since `v2019.10.15` `intake-esm` started using `concurrent.futures` when loading dataset groups. One of the shortcomings of this approach is that intake-esm would **always** spawn its own `threadpool` in order to load groups of datasets concurrently. 

This PR changes this in the following ways:

- If a user has a dask cluster already running, use it instead of spawning our own threadpool.
- If there is no dask cluster, we default to dask's threads scheduler by spawning a threadpool with `total number of threads = total number of groups` 

Also, this PR removes our half-baked progressbar functionality and uses the functionality provided by `dask.diagnostics.ProgressBar` and `distributed.progress`