### PR TITLE
Use raw path if protocol is None

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,7 +40,7 @@ shared: &shared
     - run:
         name: Running Tests
         command: |
-          pytest -n 4 --junitxml=test-reports/junit.xml --cov=./ --verbose
+          pytest -n 4 --junitxml=test-reports/junit.xml --cov=./ --verbose -p no:sugar
         no_output_timeout: 30m
     - run:
         name: Uploading code coverage report

--- a/intake_esm/core.py
+++ b/intake_esm/core.py
@@ -4,12 +4,11 @@ import json
 import logging
 
 import dask
-import fsspec
 import intake
 import numpy as np
 import pandas as pd
 
-from .merge_util import _aggregate, _create_asset_info_lookup, _to_nested_dict
+from .merge_util import _aggregate, _create_asset_info_lookup, _path_to_mapper, _to_nested_dict
 from .utils import _fetch_and_parse_json, _fetch_catalog, _get_dask_client, logger
 
 
@@ -384,8 +383,7 @@ class esm_datastore(intake.catalog.Catalog):
 
         # replace path column with mapper (dependent on filesystem type)
         mapper_dict = {
-            path: fsspec.get_mapper(path, **self.storage_options)
-            for path in self.df[path_column_name]
+            path: _path_to_mapper(path, self.storage_options) for path in self.df[path_column_name]
         }
 
         groupby_attrs = []

--- a/intake_esm/merge_util.py
+++ b/intake_esm/merge_util.py
@@ -6,6 +6,14 @@ import xarray as xr
 logger = logging.getLogger('intake-esm')
 
 
+def _path_to_mapper(path, storage_options):
+    """Convert path to mapper if necessary."""
+    if fsspec.core.split_protocol(path)[0] is not None:
+        return fsspec.get_mapper(path, **storage_options)
+    else:
+        return path
+
+
 def join_new(dsets, dim_name, coord_value, varname, options={}):
     if isinstance(varname, str):
         varname = [varname]


### PR DESCRIPTION
This PR fixes

```python
---------------------------------------------------------------------------
AttributeError                            Traceback (most recent call last)
<timed exec> in <module>
...

AttributeError: 'FSMap' object has no attribute 'tell'
```

This error occurs when an FSMap object is passed to `xr.open_dataset()`

We used to have a fix for this, and for reasons I don't recall 😄, I removed this  fix a few months ago. 

Cc @matt-long 
