### PR TITLE
Fix bug in _fetch_catalog

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,3 +1,4 @@
+import pandas as pd
 import pytest
 import requests
 
@@ -21,3 +22,13 @@ def test_fetch_catalog_local_error(sample_bad_input):
 
     with pytest.raises(FileNotFoundError):
         _fetch_catalog(data, path)
+
+
+def test_catalog_url_construction_from_relative_url():
+    url = 'https://raw.githubusercontent.com/NCAR/cesm-lens-aws/master/intake-catalogs/aws-cesm1-le.json'
+
+    data, path = _fetch_and_parse_json(url)
+
+    df = _fetch_catalog(data, path)
+
+    assert isinstance(df, pd.DataFrame)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -19,16 +19,12 @@ def test_fetch_and_parse_json_local(sample_cmip6):
 
 def test_fetch_catalog_local_error(sample_bad_input):
     data, path = _fetch_and_parse_json(sample_bad_input)
-
     with pytest.raises(FileNotFoundError):
         _fetch_catalog(data, path)
 
 
 def test_catalog_url_construction_from_relative_url():
     url = 'https://raw.githubusercontent.com/NCAR/cesm-lens-aws/master/intake-catalogs/aws-cesm1-le.json'
-
     data, path = _fetch_and_parse_json(url)
-
     df = _fetch_catalog(data, path)
-
     assert isinstance(df, pd.DataFrame)


### PR DESCRIPTION
The logic used for constructing a valid url for a catalog (when given a relative url) had a bug in it. This PR fixes this bug by using `urlunparse` and `ParseResult` from `urllib`.