### PR TITLE
Support columns with iterables in `unique()`, and `nunique()` methods

### DIFF
--- a/ci/environment-upstream-dev.yml
+++ b/ci/environment-upstream-dev.yml
@@ -2,7 +2,9 @@ name: intake-esm-dev
 channels:
   - conda-forge
 dependencies:
+  - cftime
   - codecov
+  - netcdf4
   - pip
   - pytest
   - pytest-cov

--- a/ci/environment-upstream-dev.yml
+++ b/ci/environment-upstream-dev.yml
@@ -12,6 +12,7 @@ dependencies:
   - pytest-xdist
   - toolz
   - zarr
+  - psutil
   - pip:
     - git+https://github.com/intake/intake.git
     - git+https://github.com/pydata/xarray.git

--- a/ci/environment.yml
+++ b/ci/environment.yml
@@ -2,10 +2,12 @@ name: intake-esm-dev
 channels:
   - conda-forge
 dependencies:
+  - cftime
   - codecov
   - fsspec
   - gcsfs
   - intake
+  - netcdf4
   - pip
   - pytest
   - pytest-cov

--- a/intake_esm/core.py
+++ b/intake_esm/core.py
@@ -481,15 +481,16 @@ class esm_datastore(intake.catalog.Catalog):
         return self._ds
 
 
-def _unique(df, columns):
+def _unique(df, columns=None):
     if isinstance(columns, str):
         columns = [columns]
     if not columns:
-        columns = df.columns
+        columns = df.columns.tolist()
 
     info = {}
     for col in columns:
-        uniques = np.unique(list(_flatten_list(df[col].values))).tolist()
+        values = df[col].dropna().values
+        uniques = np.unique(list(_flatten_list(values))).tolist()
         info[col] = {'count': len(uniques), 'values': uniques}
     return info
 

--- a/intake_esm/core.py
+++ b/intake_esm/core.py
@@ -2,6 +2,7 @@ import copy
 import itertools
 import json
 import logging
+from collections.abc import Iterable
 
 import dask
 import intake
@@ -211,7 +212,12 @@ class esm_datastore(intake.catalog.Catalog):
         dcpp_init_year       59
         dtype: int64
         """
-        return self.df.nunique()
+
+        uniques = self.unique(self.df.columns.tolist())
+        nuniques = {}
+        for key, val in uniques.items():
+            nuniques[key] = val['count']
+        return pd.Series(nuniques)
 
     def unique(self, columns=None):
         """Return unique values for given columns in the
@@ -483,7 +489,7 @@ def _unique(df, columns):
 
     info = {}
     for col in columns:
-        uniques = df[col].unique().tolist()
+        uniques = np.unique(list(_flatten_list(df[col].values))).tolist()
         info[col] = {'count': len(uniques), 'values': uniques}
     return info
 
@@ -622,3 +628,12 @@ def _normalize_query(query):
         if isinstance(val, str):
             q[key] = [val]
     return q
+
+
+def _flatten_list(data):
+    for item in data:
+        if isinstance(item, Iterable) and not isinstance(item, str):
+            for x in _flatten_list(item):
+                yield x
+        else:
+            yield item

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -2,6 +2,7 @@ import os
 from tempfile import TemporaryDirectory
 
 import intake
+import numpy as np
 import pandas as pd
 import pytest
 import xarray as xr
@@ -53,19 +54,26 @@ def test_col_unique(pangeo_cmip6_col):
 def test_unique():
     df = pd.DataFrame(
         {
-            'path': ['file1', 'file2', 'file3'],
-            'variable': [['A', 'B'], ['A', 'B', 'C'], ['C', 'D', 'A']],
-            'attr': [1, 2, 3],
-            'random': [set(['bx', 'by']), set(['bx', 'bz']), set(['bx', 'by'])],
+            'path': ['file1', 'file2', 'file3', 'file4'],
+            'variable': [['A', 'B'], ['A', 'B', 'C'], ['C', 'D', 'A'], 'C'],
+            'attr': [1, 2, 3, np.nan],
+            'random': [set(['bx', 'by']), set(['bx', 'bz']), set(['bx', 'by']), None],
         }
     )
     expected = {
-        'path': {'count': 3, 'values': ['file1', 'file2', 'file3']},
+        'path': {'count': 4, 'values': ['file1', 'file2', 'file3', 'file4']},
         'variable': {'count': 4, 'values': ['A', 'B', 'C', 'D']},
-        'attr': {'count': 3, 'values': [1, 2, 3]},
+        'attr': {'count': 3, 'values': [1.0, 2.0, 3.0]},
         'random': {'count': 3, 'values': ['bx', 'by', 'bz']},
     }
     actual = _unique(df, df.columns.tolist())
+    assert actual == expected
+
+    actual = _unique(df)
+    assert actual == expected
+
+    actual = _unique(df, columns='random')
+    expected = {'random': {'count': 3, 'values': ['bx', 'by', 'bz']}}
     assert actual == expected
 
 


### PR DESCRIPTION
In preparation for support of multiple variable files (for more details, see https://github.com/NCAR/intake-esm/issues/112, and https://github.com/NCAR/intake-esm-datastore/issues/55), this PR modifies the existing `nunique()` and `unique()` methods to support columns with iterables (list, tuples, etc...) 


Cc @sherimickelson 