### PR TITLE
Add html representation for the catalog object

### DIFF
--- a/intake_esm/core.py
+++ b/intake_esm/core.py
@@ -212,7 +212,7 @@ class esm_datastore(intake.catalog.Catalog):
     def _repr_html_(self):
         """
         Return an html representation for the catalog object.
-        Main for IPython notebook
+        Mainly for IPython notebook
         """
         uniques = pd.DataFrame(self.nunique(), columns=['unique'])
         text = uniques._repr_html_()

--- a/intake_esm/core.py
+++ b/intake_esm/core.py
@@ -207,7 +207,17 @@ class esm_datastore(intake.catalog.Catalog):
 
     def __repr__(self):
         """Make string representation of object."""
-        return f'<Intake-esm catalog with {len(self)} dataset(s) from {len(self.df)} asset(s)>'
+        return f'<{self.esmcol_data["id"]} catalog with {len(self)} dataset(s) from {len(self.df)} asset(s)>'
+
+    def _repr_html_(self):
+        """
+        Return an html representation for the catalog object.
+        Main for IPython notebook
+        """
+        uniques = pd.DataFrame(self.nunique(), columns=['unique'])
+        text = uniques._repr_html_()
+        output = f'<p><strong>{self.esmcol_data["id"]} catalog with {len(self)} dataset(s) from {len(self.df)} asset(s)</strong>:</p> {text}'
+        return output
 
     @classmethod
     def from_df(

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -48,7 +48,15 @@ cdf_query = dict(source_id=['CNRM-ESM2-1', 'CNRM-CM6-1', 'BCC-ESM1'], variable_i
 
 
 def test_repr(sample_cmip6_col):
-    assert 'Intake-esm catalog with' in repr(sample_cmip6_col)
+    assert 'catalog with' in repr(sample_cmip6_col)
+
+
+def test_repr_html(sample_cmip6_col):
+    text = sample_cmip6_col._repr_html_()
+    assert 'unique' in text
+    columns = sample_cmip6_col.df.columns.tolist()
+    for column in columns:
+        assert column in text
 
 
 def test_log_level_error():


### PR DESCRIPTION
This provides more information about the catalog object as an HTML repr. 


![Screen Shot 2020-04-30 at 1 05 31 PM](https://user-images.githubusercontent.com/13301940/80749233-5ebee700-8ae3-11ea-83a9-ad68e2cd19a1.png)
